### PR TITLE
Utilities

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ export {start} from 'meteor/universe:test-hooks';
 
 // Export mocha functions (describe, it etc.) and other public api
 export * from './lib/mocha';
+export * from './util';
 export {createBrowser} from './lib/puppeteer';
 export {onTest, onInterrupt};
 

--- a/util/index.js
+++ b/util/index.js
@@ -1,0 +1,1 @@
+export * from './resize';

--- a/util/index.js
+++ b/util/index.js
@@ -1,1 +1,2 @@
 export * from './resize';
+export * from './type';

--- a/util/resize.js
+++ b/util/resize.js
@@ -1,0 +1,22 @@
+export async function resize ({page}, height, width, frame = 85) {
+    await page.setViewport({height, width});
+
+    // Window frame - probably OS and WM dependent.
+    height += frame;
+
+    // Any tab.
+    const {targetInfos: [{targetId}]} = await page._client.send(
+        'Target.getTargets'
+    );
+
+    // Tab window.
+    const {windowId} = await page._client.send('Browser.getWindowForTarget', {
+        targetId
+    });
+
+    // Actually resize.
+    await page._client.send('Browser.setWindowBounds', {
+        bounds: {height, width},
+        windowId
+    });
+}

--- a/util/type.js
+++ b/util/type.js
@@ -1,0 +1,7 @@
+export async function type ({page}, selector, value) {
+  await page.click(selector);
+  await page.keyboard.down('Control');
+  await page.keyboard.press('A');
+  await page.keyboard.up('Control');
+  await page.type(selector, value);
+}


### PR DESCRIPTION
I've added few common utilities and a kind of general solution for more such helpers.

As discussed internally, first argument is `{browser, page}` in case a helper need one of them. This argument order allows user to use `.bind` easily and then migrate to built in puppeteer functions if possible. 