### PR TITLE
Move the puppeteer import

### DIFF
--- a/lib/puppeteer.js
+++ b/lib/puppeteer.js
@@ -1,5 +1,4 @@
 import {Promise} from 'meteor/promise';
-import puppeteer from 'puppeteer';
 import {closeEmptyTabs} from '../helpers/closeEmptyTabs';
 
 /**
@@ -26,6 +25,8 @@ export const createBrowser = async ({
         ...launchOptions
     } = {}
 } = {}) => {
+    // Import puppeteer only when required
+    import puppeteer from 'puppeteer';
     // Use different defaults based on environment
     const options = Object.assign(isCI ? {
         // Default options for CI mode


### PR DESCRIPTION
This PR aims to move the import of the `puppeteer` package to `createBrowser` function so it's imported only when required.